### PR TITLE
feat(eks): enable control plane logging

### DIFF
--- a/eks/eks.tf
+++ b/eks/eks.tf
@@ -37,6 +37,8 @@ resource "aws_eks_cluster" "superplane" {
     endpoint_public_access  = true
   }
 
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
   depends_on = [
     aws_iam_role_policy_attachment.eks_cluster_policy
   ]


### PR DESCRIPTION
## Security Issue

Without control plane logging enabled, there is no visibility into:
- API server requests and responses
- Authentication attempts (successful and failed)
- Authorization decisions
- Controller manager and scheduler operations

This makes it impossible to:
- Investigate security incidents or unauthorized access
- Detect brute force attacks or credential stuffing
- Audit who accessed what resources and when
- Meet compliance requirements for audit logging

## Changes

Enables EKS control plane logging with all log types:
- `api` - Kubernetes API server logs
- `audit` - Kubernetes audit logs (who did what)
- `authenticator` - IAM authenticator logs
- `controllerManager` - Controller manager logs
- `scheduler` - Scheduler logs

Logs are sent to CloudWatch Logs automatically.

## Security Risk: Low

**Why Low Risk:**
- This is a detection/visibility gap, not a direct attack vector
- Attackers cannot exploit the lack of logging directly
- However, absence of logs significantly hampers incident response
- Risk is primarily to forensics and compliance, not immediate exploitation

**Impact if Unaddressed:**
- Cannot detect ongoing attacks
- Cannot investigate past incidents
- May fail compliance audits requiring audit logs