### PR TITLE
feat(eks): add VPC flow logs for network visibility

### DIFF
--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -129,3 +129,62 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private.id
 }
+
+# -----------------------------------------------------------------------------
+# VPC Flow Logs
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = "/aws/vpc/${var.cluster_name}-flow-logs"
+  retention_in_days = 30
+
+  tags = {
+    Name = "${var.cluster_name}-vpc-flow-logs"
+  }
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "${var.cluster_name}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "vpc-flow-logs.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "${var.cluster_name}-vpc-flow-logs-policy"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "vpc" {
+  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.superplane.id
+
+  tags = {
+    Name = "${var.cluster_name}-vpc-flow-log"
+  }
+}


### PR DESCRIPTION
## Security Issue

Without VPC Flow Logs, there is no visibility into network traffic patterns:
- Cannot detect suspicious network connections
- Cannot identify data exfiltration attempts
- Cannot see unexpected external connections to/from the cluster
- Cannot audit which IPs are accessing cluster resources
- No network forensics capability during incident response

## Changes

Adds VPC Flow Logs infrastructure:
- CloudWatch Log Group with 30-day retention
- IAM role for VPC Flow Logs service
- Flow Log resource capturing ALL traffic (ACCEPT + REJECT)

## Security Risk: Low

**Why Low Risk:**
- This is a visibility gap, not a direct attack vector
- Attackers cannot exploit the lack of flow logs directly
- The risk is to detection and forensics capabilities
- Network attacks are still possible regardless of logging

**Impact if Unaddressed:**
- Data exfiltration may go undetected
- Cannot identify command-and-control traffic
- No evidence trail for network-based attacks
- Incident response significantly hampered