### PR TITLE
feat(eks): add RDS parameter group for security logging

### DIFF
--- a/eks/rds.tf
+++ b/eks/rds.tf
@@ -1,4 +1,48 @@
 # -----------------------------------------------------------------------------
+# RDS Parameter Group with Security Logging
+# -----------------------------------------------------------------------------
+
+resource "aws_db_parameter_group" "superplane" {
+  name   = "${var.db_instance_identifier}-params"
+  family = "postgres17"
+
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_checkpoints"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = "1"
+  }
+
+  parameter {
+    name         = "log_min_duration_statement"
+    value        = "1000"
+    apply_method = "pending-reboot"
+  }
+
+  tags = {
+    Name = "${var.db_instance_identifier}-params"
+  }
+}
+
+# -----------------------------------------------------------------------------
 # RDS Subnet Group
 # -----------------------------------------------------------------------------
 
@@ -62,6 +106,7 @@ resource "aws_db_instance" "superplane" {
 
   db_subnet_group_name   = aws_db_subnet_group.superplane.name
   vpc_security_group_ids = [aws_security_group.rds.id]
+  parameter_group_name   = aws_db_parameter_group.superplane.name
 
   publicly_accessible = false
   multi_az            = false


### PR DESCRIPTION
## Security Issue

Without database security logging, there is no audit trail for:
- Who connected to the database and when
- What SQL statements were executed
- Failed login attempts (potential brute force)
- Long-running queries (potential data exfiltration)
- Lock contention (potential for deadlock attacks)

## Changes

Adds a custom RDS parameter group with security logging:
- `log_statement = all` - Log all SQL statements
- `log_connections = 1` - Log successful connections
- `log_disconnections = 1` - Log session terminations  
- `log_checkpoints = 1` - Log checkpoint activity
- `log_lock_waits = 1` - Log lock wait events
- `log_min_duration_statement = 1000` - Log queries >1 second

## Security Risk: Low

**Why Low Risk:**
- This is a detection gap, not a direct attack vector
- SQL injection and unauthorized access are still possible regardless
- The risk is to detection and forensics, not exploitation
- Attackers cannot leverage missing logs as an attack vector

**Impact if Unaddressed:**
- SQL injection attempts go undetected
- Cannot identify unauthorized data access
- Brute force login attempts invisible
- No audit trail for compliance