### PR TITLE
feat(gke): enable cluster logging and monitoring

### DIFF
--- a/gke/gke.tf
+++ b/gke/gke.tf
@@ -27,6 +27,17 @@ resource "google_container_cluster" "superplane" {
     enable_private_endpoint = false
   }
 
+  logging_service    = "logging.googleapis.com/kubernetes"
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+  }
+
   node_config {
     machine_type = var.machine_type
 


### PR DESCRIPTION
## Security Issue

Without explicit cluster logging configuration:
- GKE may not collect application logs from pods
- Cannot audit SuperPlane's activities or API calls
- Limited visibility into cluster operations
- Cannot investigate security incidents effectively

The security review marked this as a **BLOCKER** because logging is fundamental to security monitoring.

## Changes

Explicitly configures GKE logging and monitoring:
- `logging_service = "logging.googleapis.com/kubernetes"`
- `monitoring_service = "monitoring.googleapis.com/kubernetes"`
- `logging_config.enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]`
- `monitoring_config.enable_components = ["SYSTEM_COMPONENTS"]`

## Security Risk: Low

**Why Low Risk:**
- This is a visibility gap, not an exploitable vulnerability
- Attackers cannot directly exploit missing logs
- The risk is to detection and incident response capabilities
- Attacks are possible regardless of logging status

**Impact if Unaddressed:**
- Cannot detect malicious pod activity
- No visibility into API abuse
- Incident response severely limited
- May fail compliance audits