### PR TITLE
feat(gke): add CloudSQL query insights and security logging

### DIFF
--- a/gke/cloudsql.tf
+++ b/gke/cloudsql.tf
@@ -53,6 +53,38 @@ resource "google_sql_database_instance" "superplane" {
         retained_backups = 7
       }
     }
+
+    insights_config {
+      query_insights_enabled  = true
+      query_string_length     = 1024
+      record_application_tags = true
+      record_client_address   = true
+    }
+
+    database_flags {
+      name  = "log_connections"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "log_disconnections"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "log_checkpoints"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "log_lock_waits"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "log_min_duration_statement"
+      value = "1000"
+    }
   }
 
   depends_on = [


### PR DESCRIPTION
## Security Issue

Without Query Insights and security database flags:
- Cannot see actual queries SuperPlane is running
- Cannot detect SQL injection attempts
- Cannot identify slow queries indicating data exfiltration
- Cannot audit database connection patterns
- Cannot detect brute force password attempts

## Changes

### Query Insights
- `query_insights_enabled = true` - Enable query monitoring
- `query_string_length = 1024` - Capture full query text
- `record_application_tags = true` - Track by application
- `record_client_address = true` - Audit client source IPs

### Security Database Flags
- `log_connections = on` - Audit connection attempts
- `log_disconnections = on` - Audit session terminations
- `log_checkpoints = on` - Monitor checkpoint activity
- `log_lock_waits = on` - Detect contention issues
- `log_min_duration_statement = 1000` - Log slow queries

## Security Risk: Low

**Why Low Risk:**
- This is a detection/monitoring gap
- SQL injection and data theft are possible regardless of logging
- Attackers cannot exploit missing query insights directly
- Risk is to detection, not to exploitation

**Impact if Unaddressed:**
- SQL injection attacks go unnoticed
- Data exfiltration not detected
- Cannot identify compromised credentials
- No forensic evidence of database abuse