### PR TITLE
feat: add pod security context for SuperPlane deployment

### DIFF
--- a/eks/helm.tf
+++ b/eks/helm.tf
@@ -361,6 +361,46 @@ resource "helm_release" "superplane" {
     value = "superplane-oidc"
   }
 
+  set {
+    name  = "podSecurityContext.runAsNonRoot"
+    value = "true"
+  }
+
+  set {
+    name  = "podSecurityContext.runAsUser"
+    value = "65534"
+  }
+
+  set {
+    name  = "podSecurityContext.fsGroup"
+    value = "65534"
+  }
+
+  set {
+    name  = "securityContext.allowPrivilegeEscalation"
+    value = "false"
+  }
+
+  set {
+    name  = "securityContext.readOnlyRootFilesystem"
+    value = "true"
+  }
+
+  set {
+    name  = "securityContext.runAsNonRoot"
+    value = "true"
+  }
+
+  set {
+    name  = "securityContext.capabilities.drop[0]"
+    value = "ALL"
+  }
+
+  set {
+    name  = "securityContext.seccompProfile.type"
+    value = "RuntimeDefault"
+  }
+
   depends_on = [
     kubernetes_namespace.superplane,
     kubernetes_secret.db_credentials,

--- a/gke/helm.tf
+++ b/gke/helm.tf
@@ -212,6 +212,46 @@ resource "helm_release" "superplane" {
     value = "superplane-oidc"
   }
 
+  set {
+    name  = "podSecurityContext.runAsNonRoot"
+    value = "true"
+  }
+
+  set {
+    name  = "podSecurityContext.runAsUser"
+    value = "65534"
+  }
+
+  set {
+    name  = "podSecurityContext.fsGroup"
+    value = "65534"
+  }
+
+  set {
+    name  = "securityContext.allowPrivilegeEscalation"
+    value = "false"
+  }
+
+  set {
+    name  = "securityContext.readOnlyRootFilesystem"
+    value = "true"
+  }
+
+  set {
+    name  = "securityContext.runAsNonRoot"
+    value = "true"
+  }
+
+  set {
+    name  = "securityContext.capabilities.drop[0]"
+    value = "ALL"
+  }
+
+  set {
+    name  = "securityContext.seccompProfile.type"
+    value = "RuntimeDefault"
+  }
+
   depends_on = [
     kubernetes_namespace.superplane,
     kubernetes_secret.db_credentials,


### PR DESCRIPTION
## Security Issue

Without security context, SuperPlane pods may:
- Run as root user (default in many containers)
- Allow privilege escalation to host
- Have writable root filesystem (malware persistence)
- Retain all Linux capabilities (container breakout)
- Use unrestricted syscalls (larger attack surface)

If an attacker compromises the SuperPlane application, weak security context makes container breakout and host compromise significantly easier.

## Changes

### Pod Security Context
- `runAsNonRoot: true` - Prevent root containers
- `runAsUser: 65534` - Run as nobody user
- `fsGroup: 65534` - Set file group to nobody

### Container Security Context
- `allowPrivilegeEscalation: false` - Block privilege escalation
- `readOnlyRootFilesystem: true` - Prevent filesystem writes
- `capabilities.drop: [ALL]` - Remove all Linux capabilities
- `seccompProfile.type: RuntimeDefault` - Apply seccomp filtering

## Security Risk: Medium

**Why Medium Risk:**
- Requires initial application compromise to exploit
- However, once compromised, lack of security context enables:
  - Container escape via privilege escalation
  - Persistence via filesystem writes
  - Host access via retained capabilities
- Defense-in-depth measure that limits blast radius

**Impact if Unaddressed:**
- Compromised container can escalate to root
- Attacker can persist malware in container filesystem
- Container breakout becomes significantly easier
- Lateral movement to host/other containers possible