### PR TITLE
feat(eks): add VPN CIDR restriction for API server access

### DIFF
--- a/eks/eks.tf
+++ b/eks/eks.tf
@@ -34,7 +34,8 @@ resource "aws_eks_cluster" "superplane" {
   vpc_config {
     subnet_ids              = concat(aws_subnet.public[*].id, aws_subnet.private[*].id)
     endpoint_private_access = true
-    endpoint_public_access  = true
+    endpoint_public_access  = var.enable_public_access
+    public_access_cidrs     = length(var.vpn_cidr_blocks) > 0 ? var.vpn_cidr_blocks : null
   }
 
   depends_on = [

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -129,3 +129,19 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.0.0.0/16"
 }
+
+# -----------------------------------------------------------------------------
+# Optional Variables - Security
+# -----------------------------------------------------------------------------
+
+variable "vpn_cidr_blocks" {
+  description = "CIDR blocks allowed to access the EKS API server (VPN IPs). Set to restrict public access."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_public_access" {
+  description = "Whether to enable public access to the EKS API server. Set to false to restrict to VPN only."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Security Issue

The EKS API server has `endpoint_public_access = true` with no IP whitelisting:
- API server is accessible from any IP on the internet
- Exposed to credential brute force attacks
- Exposed to credential stuffing attacks
- No network-level defense for the control plane
- Stolen credentials can be used from anywhere

The security review noted: "Services do not need exposure beyond VPN IPs"

## Changes

Adds optional VPN CIDR restriction:
- `vpn_cidr_blocks` - CIDR blocks allowed to access API
- `enable_public_access` - Toggle public API access
- When set, only specified IPs can reach the API server

## Security Risk: Medium

**Why Medium Risk:**
- API server exposure increases attack surface significantly
- Brute force attacks against the API are possible from anywhere
- Stolen kubeconfig/tokens can be used from any location
- However, still requires valid credentials to exploit
- Not a direct code execution vulnerability

**Impact if Unaddressed:**
- Credential stuffing attacks from botnets
- Brute force against service accounts
- Stolen credentials usable from anywhere globally
- No ability to geo-fence or IP-restrict access
- Increased reconnaissance by attackers scanning for K8s APIs