### PR TITLE
feat(gke): add private nodes and master authorized networks

### DIFF
--- a/gke/gke.tf
+++ b/gke/gke.tf
@@ -21,10 +21,23 @@ resource "google_container_cluster" "superplane" {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
 
-  # Private cluster config for security
   private_cluster_config {
-    enable_private_nodes    = false
+    enable_private_nodes    = var.enable_private_nodes
     enable_private_endpoint = false
+    master_ipv4_cidr_block  = var.enable_private_nodes ? var.master_ipv4_cidr_block : null
+  }
+
+  dynamic "master_authorized_networks_config" {
+    for_each = length(var.master_authorized_cidr_blocks) > 0 ? [1] : []
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.master_authorized_cidr_blocks
+        content {
+          cidr_block   = cidr_blocks.value.cidr_block
+          display_name = cidr_blocks.value.display_name
+        }
+      }
+    }
   }
 
   node_config {

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -126,3 +126,28 @@ variable "network" {
   type        = string
   default     = "default"
 }
+
+# -----------------------------------------------------------------------------
+# Optional Variables - Security
+# -----------------------------------------------------------------------------
+
+variable "enable_private_nodes" {
+  description = "Whether to enable private nodes (nodes without public IPs)"
+  type        = bool
+  default     = true
+}
+
+variable "master_authorized_cidr_blocks" {
+  description = "CIDR blocks authorized to access the GKE master (VPN IPs)"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "CIDR block for the GKE master (required when enable_private_nodes is true)"
+  type        = string
+  default     = "172.16.0.0/28"
+}


### PR DESCRIPTION
## Security Issue

### Public Nodes
GKE nodes have public IP addresses (`enable_private_nodes = false`):
- Nodes directly accessible from the internet
- SSH brute force attacks possible
- Node-level exploits can be attempted directly
- Increased attack surface for the cluster

### No Master Authorized Networks
API endpoint accessible from any IP with valid credentials:
- Same risks as EKS public API (brute force, credential stuffing)
- No network-level defense for control plane

The security review marked Master Authorized Networks as a **BLOCKER**.

## Changes

- `enable_private_nodes` - Nodes without public IPs (default: true)
- `master_authorized_cidr_blocks` - Restrict API access to VPN IPs
- `master_ipv4_cidr_block` - Master CIDR for private clusters

## Security Risk: High

**Why High Risk:**
- Public nodes are directly attackable from the internet
- Node compromise = potential cluster compromise
- CVEs in node OS/kubelet directly exploitable
- No network barrier between attacker and nodes
- API exposure enables credential attacks globally

**Impact if Unaddressed:**
- Direct attacks on node SSH/services
- Exploitation of node-level vulnerabilities
- Lateral movement after node compromise
- Credential attacks from anywhere in the world
- No ability to restrict access by network location