### PR TITLE
feat(gke): reduce node OAuth scopes to minimum required

### DIFF
--- a/gke/gke.tf
+++ b/gke/gke.tf
@@ -31,7 +31,9 @@ resource "google_container_cluster" "superplane" {
     machine_type = var.machine_type
 
     oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
     ]
 
     workload_metadata_config {


### PR DESCRIPTION
## Security Issue

GKE nodes have `cloud-platform` OAuth scope:
- Grants full access to ALL GCP APIs
- Any process on the node can access any GCP service
- Node compromise = full GCP project access
- Massively violates principle of least privilege

Attack scenario:
1. Attacker compromises a pod via application vulnerability
2. Pod escapes to node (or uses node credentials via IMDS)
3. Attacker now has full GCP API access
4. Can access Cloud Storage, databases, other services
5. Lateral movement across entire GCP project

## Changes

Replaces `cloud-platform` with minimal scopes:
- `devstorage.read_only` - Pull container images only
- `logging.write` - Send logs only
- `monitoring` - Send metrics only

Pods use Workload Identity for GCP access instead.

## Security Risk: High

**Why High Risk:**
- Node compromise immediately grants full GCP access
- No privilege separation between node and GCP project
- Single container escape = project-wide compromise
- Attacker can:
  - Access all Cloud Storage buckets
  - Read/write all databases
  - Modify IAM policies
  - Launch resources for cryptomining
  - Exfiltrate data from any GCP service

**Impact if Unaddressed:**
- Container escape becomes project-wide breach
- Blast radius of node compromise is entire GCP project
- No containment of compromised workloads
- Lateral movement trivial after node access