### PR TITLE
feat(eks): enforce IMDSv2 and remove redundant EBS CSI policy

### DIFF
--- a/eks/eks.tf
+++ b/eks/eks.tf
@@ -76,9 +76,26 @@ resource "aws_iam_role_policy_attachment" "eks_container_registry" {
   role       = aws_iam_role.eks_nodes.name
 }
 
-resource "aws_iam_role_policy_attachment" "eks_ebs_csi_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-  role       = aws_iam_role.eks_nodes.name
+# -----------------------------------------------------------------------------
+# Launch Template with IMDSv2 Enforcement
+# -----------------------------------------------------------------------------
+
+resource "aws_launch_template" "eks_nodes" {
+  name_prefix = "${var.cluster_name}-nodes-"
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"  # Enforces IMDSv2
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "${var.cluster_name}-node"
+    }
+  }
 }
 
 # -----------------------------------------------------------------------------
@@ -99,11 +116,15 @@ resource "aws_eks_node_group" "superplane" {
 
   instance_types = [var.instance_type]
 
+  launch_template {
+    id      = aws_launch_template.eks_nodes.id
+    version = aws_launch_template.eks_nodes.latest_version
+  }
+
   depends_on = [
     aws_iam_role_policy_attachment.eks_worker_node_policy,
     aws_iam_role_policy_attachment.eks_cni_policy,
-    aws_iam_role_policy_attachment.eks_container_registry,
-    aws_iam_role_policy_attachment.eks_ebs_csi_policy
+    aws_iam_role_policy_attachment.eks_container_registry
   ]
 }
 
@@ -148,7 +169,6 @@ resource "aws_eks_addon" "ebs_csi" {
 
   depends_on = [
     aws_eks_node_group.superplane,
-    aws_iam_role_policy_attachment.eks_ebs_csi_policy,
     aws_iam_role_policy_attachment.ebs_csi
   ]
 }


### PR DESCRIPTION
## Security Issue

### IMDSv1 Vulnerability
EKS nodes allow IMDSv1 (Instance Metadata Service v1):
- IMDSv1 is vulnerable to SSRF attacks
- Any SSRF in any application can retrieve node IAM credentials
- Simple HTTP GET to 169.254.169.254 returns credentials
- No authentication required for IMDSv1

Attack scenario:
1. Attacker finds SSRF in SuperPlane or any workload
2. Makes request to http://169.254.169.254/latest/meta-data/iam/security-credentials/
3. Retrieves temporary AWS credentials for the node role
4. Uses credentials to access AWS services

### Overly Permissive Node Role
Worker nodes have EBS CSI policy attached directly:
- Grants EBS permissions to all processes on node
- IRSA already provides this to the CSI driver specifically
- Unnecessary privilege on node level

## Changes

### IMDSv2 Enforcement
- `http_tokens = "required"` - Blocks IMDSv1 entirely
- `http_put_response_hop_limit = 1` - Prevents container IMDS access

### IAM Cleanup
- Removes redundant EBS CSI policy from node role
- CSI driver continues working via IRSA

## Security Risk: Critical

**Why Critical Risk:**
- SSRF → AWS credentials is a well-known, actively exploited attack
- Any SSRF vulnerability becomes a credential theft vector
- Node credentials often have significant AWS permissions
- Attack is trivial once SSRF is found (simple HTTP GET)
- Cloud metadata attacks are #1 cause of cloud breaches

**Impact if Unaddressed:**
- SSRF in any pod = AWS credential theft
- Stolen credentials enable:
  - S3 bucket access
  - RDS database access
  - EC2 instance manipulation
  - Lateral movement across AWS account
- Capital One breach (2019) used this exact technique