### PR TITLE
feat(eks): scope LB controller IAM policy to cluster resources

### DIFF
--- a/eks/helm.tf
+++ b/eks/helm.tf
@@ -25,14 +25,9 @@ resource "aws_iam_role" "aws_load_balancer_controller" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
-  policy_arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
-  role       = aws_iam_role.aws_load_balancer_controller.name
-}
-
-# Additional policy for NLB controller
+# Custom policy with resource-based conditions scoped to cluster-tagged resources
 resource "aws_iam_role_policy" "aws_load_balancer_controller" {
-  name = "${var.cluster_name}-nlb-controller-policy"
+  name = "${var.cluster_name}-lb-controller-policy"
   role = aws_iam_role.aws_load_balancer_controller.id
 
   policy = jsonencode({
@@ -51,21 +46,156 @@ resource "aws_iam_role_policy" "aws_load_balancer_controller" {
           "ec2:DescribeAccountAttributes",
           "ec2:DescribeAddresses",
           "ec2:DescribeInternetGateways",
-          "ec2:CreateSecurityGroup",
-          "ec2:CreateTags",
-          "ec2:DeleteTags",
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:DeleteSecurityGroup"
+          "ec2:DescribeCoipPools",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeVpcPeeringConnections"
         ]
         Resource = "*"
       },
       {
         Effect = "Allow"
         Action = [
-          "elasticloadbalancing:*"
+          "ec2:CreateSecurityGroup"
+        ]
+        Resource = "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:vpc/${aws_vpc.superplane.id}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateSecurityGroup"
+        ]
+        Resource = "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:security-group/*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
         ]
         Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ]
+        Resource = [
+          "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:security-group/*",
+          "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:subnet/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = ["owned", "shared"]
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/*",
+          "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:targetgroup/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}" = "owned"
+          }
+        }
       },
       {
         Effect = "Allow"
@@ -78,6 +208,35 @@ resource "aws_iam_role_policy" "aws_load_balancer_controller" {
             "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
           }
         }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:DescribeCertificate",
+          "acm:ListCertificates",
+          "cognito-idp:DescribeUserPoolClient"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ]
+        Resource = "*"
       }
     ]
   })
@@ -127,7 +286,7 @@ resource "helm_release" "aws_load_balancer_controller" {
 
   depends_on = [
     aws_eks_node_group.superplane,
-    aws_iam_role_policy_attachment.aws_load_balancer_controller
+    aws_iam_role_policy.aws_load_balancer_controller
   ]
 }
 


### PR DESCRIPTION
## Security Issue

AWS Load Balancer Controller has `ElasticLoadBalancingFullAccess`:
- Can create/modify/delete ANY load balancer in the account
- Can modify ANY security group in the account
- Not scoped to the specific cluster
- Account-wide blast radius if compromised

The security review noted: "Wildcard IAM permissions on EC2 security groups (Resource = \"*\")"

Attack scenario:
1. Attacker compromises LB controller pod or service account
2. Uses credentials to:
   - Create rogue load balancers for data exfiltration
   - Modify existing LBs to intercept traffic (MITM)
   - Open security groups to allow unauthorized access
   - Delete production load balancers (DoS)
3. All actions affect ENTIRE AWS account, not just this cluster

## Changes

Replaces managed policy with scoped inline policy:
- All mutating actions require cluster tag: `kubernetes.io/cluster/${cluster_name}=owned`
- Security group changes scoped to cluster VPC
- Cannot affect resources outside this cluster

## Security Risk: High

**Why High Risk:**
- Compromised controller = account-wide access
- LB controller runs in-cluster, exposed to pod-level attacks
- Service account token theft enables credential use
- Permissions extend far beyond what's needed
- Can modify network infrastructure (security groups)

**Impact if Unaddressed:**
- Controller compromise affects entire AWS account
- Can intercept traffic to ANY application (MITM)
- Can open security groups for lateral movement
- Can cause account-wide outages
- No blast radius containment