### PR TITLE
Fix encryption key size from 64 to 32 bytes

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -27,7 +27,7 @@ resource "random_password" "jwt_secret" {
 }
 
 resource "random_password" "encryption_key" {
-  length  = 64
+  length  = 32
   special = false
 }
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -46,7 +46,7 @@ resource "random_password" "jwt_secret" {
 }
 
 resource "random_password" "encryption_key" {
-  length  = 64
+  length  = 32
   special = false
 }
 


### PR DESCRIPTION
## Summary

- Fix `random_password.encryption_key` length from 64 to 32 in both EKS and GKE modules

## Why this is the right change

AES only accepts key sizes of 16, 24, or 32 bytes. The current 64-character key causes `crypto/aes: invalid key size 64` errors whenever SuperPlane attempts to encrypt integration credentials (e.g., Slack bot tokens, GitHub App private keys). This makes all integrations that store encrypted credentials completely non-functional on fresh deployments.

The SuperPlane application uses Go's `crypto/aes.NewCipher()` which strictly validates key length. The E2E test suite in the SuperPlane repo itself uses a 32-character key (`"0123456789abcdef0123456789abcdef"` in `test/e2e/test_context.go`), confirming 32 is the intended size.

## Why this is safe

- **New deployments:** Will get a valid 32-byte key and integrations will work out of the box.
- **Existing deployments with no working integrations (most likely):** Since encryption was broken, no data was successfully encrypted with the old key. Terraform will replace the key, and integrations can be set up fresh.
- **Existing deployments with working integrations (unlikely):** Operators should be aware that Terraform will want to replace the `random_password` resource, which regenerates the key. Any data encrypted with the old key would need to be re-entered. However, this scenario is extremely unlikely since the 64-byte key would have always failed at `aes.NewCipher()`.

## Test plan

- [x] Deploy a fresh EKS cluster and verify integrations that store encrypted credentials (e.g., Slack, GitHub) work without `crypto/aes` errors
- [x] Deploy a fresh GKE cluster and verify the same
- [x] Confirm the generated key is exactly 32 characters